### PR TITLE
chore: modernize Terraform and provider versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ module "mod_apim" {
 | Name | Version |
 |------|---------|
 | azurenoopsutils | ~> 1.0.4 |
-| azurerm | ~> 3.22 |
+| azurerm | ~> 3.116 |
 ## Modules
 
 | Name | Source | Version |

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,7 @@ module "mod_apim" {
 | Name | Version |
 |------|---------|
 | azurenoopsutils | ~> 1.0.4 |
-| azurerm | ~> 3.22 |
+| azurerm | ~> 3.116 |
 ## Modules
 
 | Name | Source | Version |

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.22"
+      version = "~> 3.116"
     }
     azurenoopsutils = {
       source  = "azurenoops/azurenoopsutils"

--- a/versions.tf
+++ b/versions.tf
@@ -2,11 +2,11 @@
 # Licensed under the MIT License.
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.22"
+      version = "~> 3.116"
     }
     azurenoopsutils = {
       source  = "azurenoops/azurenoopsutils"


### PR DESCRIPTION
## Summary

Modernize version constraints to current standards.

### Changes
- Terraform `>= 1.3` → `>= 1.9`
- azurerm `~> 3.22` → `~> 3.116`
- azurenoopsutils → `~> 1.0.4`
- Updated examples and documentation

Closes #4