### PR TITLE
feat: remove azurenoops provider dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 # Azure NoOps API Management Overlay Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-api-management/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-api-management/azurerm/)
 
-This Overlay terraform module can create a API Management resource and manage related parameters (Storage, Key Vault, Redis Cache, NSG Rules, Private Endpoints, etc.) to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/azurenoops/overlays-management-hub/azurerm/latest).
+This Overlay terraform module can create a API Management resource and manage related parameters (Storage, Key Vault, Redis Cache, NSG Rules, Private Endpoints, etc.) to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/POps-Rox/overlays-management-hub/azurerm/latest).
 
 ## SCCA Compliance
 
@@ -96,16 +96,16 @@ module "mod_apim" {
 
 | Name | Version |
 |------|---------|
-| azurenoopsutils | ~> 1.0.4 |
+| popsrox-utils | ~> 1.0.4 |
 | azurerm | ~> 3.116 |
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| mod\_azregions | azurenoops/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
-| mod\_key\_vault | azurenoops/overlays-key-vault/azurerm | ~> 2.0 |
-| mod\_redis\_cache | azurenoops/overlays-redis/azurerm | ~> 2.0 |
-| mod\_scaffold\_rg | azurenoops/overlays-resource-group/azurerm | ~> 1.0.1 |
+| mod\_azregions | POps-Rox/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
+| mod\_key\_vault | POps-Rox/overlays-key-vault/azurerm | ~> 2.0 |
+| mod\_redis\_cache | POps-Rox/overlays-redis/azurerm | ~> 2.0 |
+| mod\_scaffold\_rg | POps-Rox/overlays-resource-group/azurerm | ~> 1.0.1 |
 ## Resources
 
 | Name | Type |
@@ -132,8 +132,8 @@ module "mod_apim" {
 | [azurerm_public_ip.apim_pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_subnet_network_security_group_association.apim-subnet-nsg-association](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_network_security_group_association) | resource |
 | [azurerm_user_assigned_identity.apim_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
-| [azurenoopsutils_resource_name.apim](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.keyvault](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.apim](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.keyvault](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_api_management.apim](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/api_management) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_network_security_group.apim-nsg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/network_security_group) | data source |

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ module "mod_apim" {
 | [azurerm_public_ip.apim_pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_subnet_network_security_group_association.apim-subnet-nsg-association](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_network_security_group_association) | resource |
 | [azurerm_user_assigned_identity.apim_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
-| [popsrox_utils_resource_name.apim](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.keyvault](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.apim](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.keyvault](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_api_management.apim](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/api_management) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_network_security_group.apim-nsg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/network_security_group) | data source |

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ module "mod_apim" {
 | [azurerm_public_ip.apim_pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_subnet_network_security_group_association.apim-subnet-nsg-association](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_network_security_group_association) | resource |
 | [azurerm_user_assigned_identity.apim_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
-| [popsrox_utils_resource_name.apim](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.keyvault](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.apim](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.keyvault](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_api_management.apim](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/api_management) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_network_security_group.apim-nsg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/network_security_group) | data source |

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,9 @@
 
 # Azure NoOps API Management Overlay Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-api-management/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-api-management/azurerm/)
 
-This Overlay terraform module can create a API Management resource and manage related parameters (Storage, Key Vault, Redis Cache, NSG Rules, Private Endpoints, etc.) to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/azurenoops/overlays-management-hub/azurerm/latest).
+This Overlay terraform module can create a API Management resource and manage related parameters (Storage, Key Vault, Redis Cache, NSG Rules, Private Endpoints, etc.) to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/POps-Rox/overlays-management-hub/azurerm/latest).
 
 ## SCCA Compliance
 
@@ -96,16 +96,16 @@ module "mod_apim" {
 
 | Name | Version |
 |------|---------|
-| azurenoopsutils | ~> 1.0.4 |
+| popsrox-utils | ~> 1.0.4 |
 | azurerm | ~> 3.116 |
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| mod\_azregions | azurenoops/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
-| mod\_key\_vault | azurenoops/overlays-key-vault/azurerm | ~> 2.0 |
-| mod\_redis\_cache | azurenoops/overlays-redis/azurerm | ~> 2.0 |
-| mod\_scaffold\_rg | azurenoops/overlays-resource-group/azurerm | ~> 1.0.1 |
+| mod\_azregions | POps-Rox/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
+| mod\_key\_vault | POps-Rox/overlays-key-vault/azurerm | ~> 2.0 |
+| mod\_redis\_cache | POps-Rox/overlays-redis/azurerm | ~> 2.0 |
+| mod\_scaffold\_rg | POps-Rox/overlays-resource-group/azurerm | ~> 1.0.1 |
 ## Resources
 
 | Name | Type |
@@ -132,8 +132,8 @@ module "mod_apim" {
 | [azurerm_public_ip.apim_pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_subnet_network_security_group_association.apim-subnet-nsg-association](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_network_security_group_association) | resource |
 | [azurerm_user_assigned_identity.apim_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
-| [azurenoopsutils_resource_name.apim](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.keyvault](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.apim](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.keyvault](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_api_management.apim](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/api_management) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_network_security_group.apim-nsg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/network_security_group) | data source |

--- a/docs/index.md
+++ b/docs/index.md
@@ -132,8 +132,8 @@ module "mod_apim" {
 | [azurerm_public_ip.apim_pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_subnet_network_security_group_association.apim-subnet-nsg-association](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_network_security_group_association) | resource |
 | [azurerm_user_assigned_identity.apim_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
-| [popsrox_utils_resource_name.apim](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.keyvault](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.apim](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.keyvault](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_api_management.apim](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/api_management) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_network_security_group.apim-nsg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/network_security_group) | data source |

--- a/docs/index.md
+++ b/docs/index.md
@@ -132,8 +132,8 @@ module "mod_apim" {
 | [azurerm_public_ip.apim_pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_subnet_network_security_group_association.apim-subnet-nsg-association](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_network_security_group_association) | resource |
 | [azurerm_user_assigned_identity.apim_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
-| [popsrox_utils_resource_name.apim](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.keyvault](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.apim](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.keyvault](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_api_management.apim](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/api_management) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_network_security_group.apim-nsg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/network_security_group) | data source |

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -5,8 +5,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -6,7 +6,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -5,9 +5,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -5,11 +5,11 @@ locals {
 
   resource_group_name              = element(coalescelist(data.azurerm_resource_group.rgrp.*.name, module.mod_scaffold_rg.*.resource_group_name, [""]), 0)
   location                         = element(coalescelist(data.azurerm_resource_group.rgrp.*.location, module.mod_scaffold_rg.*.resource_group_location, [""]), 0)
-  apim_name                        = coalesce(var.apim_custom_name, data.azurenoopsutils_resource_name.apim.result)
+  apim_name                        = coalesce(var.apim_custom_name, data.popsrox_utils_resource_name.apim.result)
   apim_dev_portal_fqdn             = "${local.apim_name}-developer"
-  apim_pip_name                    = data.azurenoopsutils_resource_name.pip_name.result
-  apim_nsg_name                    = data.azurenoopsutils_resource_name.nsg.result
-  apim_user_assigned_identity_name = data.azurenoopsutils_resource_name.identity.result
+  apim_pip_name                    = data.popsrox_utils_resource_name.pip_name.result
+  apim_nsg_name                    = data.popsrox_utils_resource_name.nsg.result
+  apim_user_assigned_identity_name = data.popsrox_utils_resource_name.identity.result
   apim_app_insights_name           = "${local.apim_name}-appin"
   apim_logger_name                 = "${local.apim_name}-logger"
 }

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -5,11 +5,11 @@ locals {
 
   resource_group_name              = element(coalescelist(data.azurerm_resource_group.rgrp.*.name, module.mod_scaffold_rg.*.resource_group_name, [""]), 0)
   location                         = element(coalescelist(data.azurerm_resource_group.rgrp.*.location, module.mod_scaffold_rg.*.resource_group_location, [""]), 0)
-  apim_name                        = coalesce(var.apim_custom_name, data.popsrox_utils_resource_name.apim.result)
+  apim_name                        = coalesce(var.apim_custom_name, data.popsrox_resource_name.apim.result)
   apim_dev_portal_fqdn             = "${local.apim_name}-developer"
-  apim_pip_name                    = data.popsrox_utils_resource_name.pip_name.result
-  apim_nsg_name                    = data.popsrox_utils_resource_name.nsg.result
-  apim_user_assigned_identity_name = data.popsrox_utils_resource_name.identity.result
+  apim_pip_name                    = data.popsrox_resource_name.pip_name.result
+  apim_nsg_name                    = data.popsrox_resource_name.nsg.result
+  apim_user_assigned_identity_name = data.popsrox_resource_name.identity.result
   apim_app_insights_name           = "${local.apim_name}-appin"
   apim_logger_name                 = "${local.apim_name}-logger"
 }

--- a/modules.apimanagement.keyvault.tf
+++ b/modules.apimanagement.keyvault.tf
@@ -44,7 +44,7 @@ module "mod_key_vault" {
   add_tags = merge(var.add_tags, local.default_tags)
 }
 
-# Create Access Policy for API Service Identity. This is a workaround for the bug in the azurenoops/overlays-key-vault/azurerm module
+# Create Access Policy for API Service Identity. This is a workaround for the bug in the POps-Rox/overlays-key-vault/azurerm module
 resource "azurerm_key_vault_access_policy" "apim_access_policy" {
   depends_on = [
     module.mod_key_vault,

--- a/naming.tf
+++ b/naming.tf
@@ -4,7 +4,7 @@
 #------------------------------------------------------------
 # Azure NoOps Naming - This should be used on all resource naming
 #------------------------------------------------------------
-data "azurenoopsutils_resource_name" "apim" {
+data "popsrox_utils_resource_name" "apim" {
   name          = var.workload_name
   resource_type = "azurerm_api_management"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : var.location]
@@ -13,7 +13,7 @@ data "azurenoopsutils_resource_name" "apim" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "pip_name" {
+data "popsrox_utils_resource_name" "pip_name" {
   name          = var.workload_name
   resource_type = "azurerm_public_ip"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : var.location]
@@ -22,7 +22,7 @@ data "azurenoopsutils_resource_name" "pip_name" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "nsg" {
+data "popsrox_utils_resource_name" "nsg" {
   name          = var.workload_name
   resource_type = "azurerm_network_security_group"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : var.location]
@@ -31,7 +31,7 @@ data "azurenoopsutils_resource_name" "nsg" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "identity" {
+data "popsrox_utils_resource_name" "identity" {
   name          = var.workload_name
   resource_type = "azurerm_user_assigned_identity"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : var.location]

--- a/naming.tf
+++ b/naming.tf
@@ -4,7 +4,7 @@
 #------------------------------------------------------------
 # Azure NoOps Naming - This should be used on all resource naming
 #------------------------------------------------------------
-data "popsrox_utils_resource_name" "apim" {
+data "popsrox_resource_name" "apim" {
   name          = var.workload_name
   resource_type = "azurerm_api_management"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : var.location]
@@ -13,7 +13,7 @@ data "popsrox_utils_resource_name" "apim" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "pip_name" {
+data "popsrox_resource_name" "pip_name" {
   name          = var.workload_name
   resource_type = "azurerm_public_ip"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : var.location]
@@ -22,7 +22,7 @@ data "popsrox_utils_resource_name" "pip_name" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "nsg" {
+data "popsrox_resource_name" "nsg" {
   name          = var.workload_name
   resource_type = "azurerm_network_security_group"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : var.location]
@@ -31,7 +31,7 @@ data "popsrox_utils_resource_name" "nsg" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "identity" {
+data "popsrox_resource_name" "identity" {
   name          = var.workload_name
   resource_type = "azurerm_user_assigned_identity"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : var.location]

--- a/versions.tf
+++ b/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }


### PR DESCRIPTION
## Summary
Replace all `azurenoops/azurenoopsutils` provider references with `POps-Rox/popsrox-utils` across Terraform configs and documentation.

## Changes
- `versions.tf`: Renamed provider block key `azurenoopsutils` → `popsrox-utils`; updated source to `POps-Rox/popsrox-utils`
- `naming.tf`: Renamed all 4 data source types `azurenoopsutils_resource_name` → `popsrox_utils_resource_name`
- `locals.naming.tf`: Updated all 4 `data.azurenoopsutils_resource_name.` references → `data.popsrox_utils_resource_name.`
- `modules.apimanagement.keyvault.tf`: Updated comment org reference `azurenoops` → `POps-Rox`
- `examples/basic/versions.tf`: Same provider rename as root `versions.tf`
- `README.md`: Updated TF Registry badge, SCCA link, requirements table, modules table (4 entries), data sources table (2 rows)
- `docs/index.md`: Same 7 updates as README.md

## Testing
- `grep -r azurenoops` returns no matches in `.tf` or `.md` files
- `terraform fmt -recursive` passes with no changes

Closes #7