### PR TITLE
fix: correct truncated module source slugs (tf-az-overlays → terraform-az-overlays)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,10 +1,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: tf-az-overlays-apimanagement
+  name: terraform-az-overlays-apimanagement
   description: Terraform overlay module for Azure API Management
   annotations:
-    github.com/project-slug: POps-Rox/tf-az-overlays-apimanagement
+    github.com/project-slug: POps-Rox/terraform-az-overlays-apimanagement
     backstage.io/techdocs-ref: dir:.
   tags:
     - terraform
@@ -12,7 +12,7 @@ metadata:
     - azure
     - platform-ops
   links:
-    - url: https://github.com/POps-Rox/tf-az-overlays-apimanagement
+    - url: https://github.com/POps-Rox/terraform-az-overlays-apimanagement
       title: GitHub Repository
       icon: github
 spec:

--- a/examples/basic/dependencies.tf
+++ b/examples/basic/dependencies.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "eastus"
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -9,7 +9,7 @@ module "mod_apim" {
     azurerm_subnet.pe_subnet
   ]
   source = "../.."
-  #source  = "github.com/POps-Rox/tf-az-overlays-apimanagement"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-apimanagement"
   #version = ">= 1.0.0"
 
   providers = {

--- a/modules.apimanagement.cache.tf
+++ b/modules.apimanagement.cache.tf
@@ -5,7 +5,7 @@ module "mod_redis_cache" {
   depends_on = [
     module.mod_scaffold_rg,
   ]
-  source                       = "github.com/POps-Rox/tf-az-overlays-redis"
+  source                       = "github.com/POps-Rox/terraform-az-overlays-redis"
   count                        = var.enable_redis_cache ? 1 : 0
   location                     = lower(local.location)
   org_name                     = lower(var.org_name)

--- a/modules.apimanagement.keyvault.tf
+++ b/modules.apimanagement.keyvault.tf
@@ -5,7 +5,7 @@ module "mod_key_vault" {
   depends_on = [
     azurerm_user_assigned_identity.apim_identity
   ]
-  source = "github.com/POps-Rox/tf-az-overlays-keyvault"
+  source = "github.com/POps-Rox/terraform-az-overlays-keyvault"
   count  = var.create_apim_keyvault ? 1 : 0
   providers = {
     azurerm     = azurerm

--- a/modules.apimanagement.scaffolding.tf
+++ b/modules.apimanagement.scaffolding.tf
@@ -6,7 +6,7 @@
 #--------------------------------------
 # This module will lookup the Azure Region and return the short name for the region
 module "mod_azregions" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = var.location
 }
@@ -22,7 +22,7 @@ data "azurerm_resource_group" "rgrp" {
 }
 
 module "mod_scaffold_rg" {
-  source = "github.com/POps-Rox/tf-az-overlays-resourcegroup"
+  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup"
 
   count = var.create_apim_resource_group ? 1 : 0
 


### PR DESCRIPTION
## Summary
GitHub renamed these repos from `tf-az-overlays-*` to `terraform-az-overlays-*` in a prior cleanup, but module `source =` references in `.tf` files and `catalog-info.yaml` annotations still use the old slug. Terraform module downloads currently succeed only via GitHub's 301 redirect — fragile and prone to break.

## Changes
- All `.tf` files: `POps-Rox/tf-az-overlays-*` → `POps-Rox/terraform-az-overlays-*`
- All `.tf` files: `POps-Rox/tf-az-entra-overlays-*` → `POps-Rox/terraform-az-entra-overlays-*`
- `catalog-info.yaml`: `metadata.name` and `github.com/project-slug` annotation updated to match actual repo name

## Validation
```bash
grep -rln 'POps-Rox/tf-az-overlays\|pops-rox/tf-az-overlays' --include='*.tf' .
grep -l 'tf-az-overlays\|tf-az-entra-overlays' catalog-info.yaml
```
Both return no output after this PR.

Part of the POps-Rox Go-To-Market initiative.